### PR TITLE
fix: install git in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:24-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /action
 
 COPY package.json pnpm-lock.yaml tsconfig.json ./

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,9 @@
 import { writeFileSync } from "node:fs";
+import type * as github from "@actions/github";
 import { generateMarkdown, getFilePath } from "./generate-markdown.js";
 import type { Issue } from "./generate-markdown.js";
+
+export type Octokit = ReturnType<typeof github.getOctokit>;
 
 export interface ActionContext {
   issue: Issue;
@@ -18,20 +21,7 @@ export interface ActionContext {
 
 export interface ActionDeps {
   exec: (cmd: string, args: string[]) => Promise<number>;
-  octokit: {
-    rest: {
-      pulls: {
-        create: (params: {
-          owner: string;
-          repo: string;
-          title: string;
-          head: string;
-          base: string;
-          body: string;
-        }) => Promise<{ data: { html_url: string } }>;
-      };
-    };
-  };
+  octokit: Octokit;
   writeFile?: (path: string, content: string) => void;
 }
 

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { runAction } from "../src/action.js";
-import type { ActionContext, ActionDeps } from "../src/action.js";
+import type { ActionContext, ActionDeps, Octokit } from "../src/action.js";
 
 describe("runAction", () => {
   let mockContext: ActionContext;
@@ -43,7 +43,7 @@ describe("runAction", () => {
           }),
         },
       },
-    };
+    } as unknown as Octokit;
   });
 
   it("正しいブランチ名を返す", async () => {


### PR DESCRIPTION
## Summary
- `node:24-slim` に `git` が含まれていないため、アクション実行時に `Unable to locate executable file: git` エラーで失敗していた
- Dockerfile に `apt-get install git` を追加して修正

## Test plan
- [ ] 修正済み Issue を Reopen → Close して、ワークフローが正常完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)