### PR TITLE
fix: configure git user for commits in Docker container

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -46,6 +46,10 @@ export async function runAction(
   // Docker コンテナ内の所有者不一致を回避
   await exec("git", ["config", "--global", "safe.directory", "/github/workspace"]);
 
+  // Docker コンテナ内の git ユーザー設定
+  await exec("git", ["config", "user.name", "github-actions[bot]"]);
+  await exec("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+
   // ブランチ作成
   await exec("git", ["checkout", "-b", branchName]);
 

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -75,6 +75,8 @@ describe("runAction", () => {
 
     expect(calls).toEqual([
       "git config --global safe.directory /github/workspace",
+      "git config user.name github-actions[bot]",
+      "git config user.email 41898282+github-actions[bot]@users.noreply.github.com",
       "git checkout -b content/issue-42",
       "mkdir -p src/content/posts",
       "git add src/content/posts/42.md",


### PR DESCRIPTION
Docker コンテナ内に git の user.name / user.email が設定されていないため、git commit が失敗している件の対応