### PR TITLE
fix: add ca-certificates for HTTPS access in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /action
 


### PR DESCRIPTION
Docker コンテナ内に CA 証明書がないため、HTTPS で GitHub に接続できていません。node:24-slim は最小イメージなので ca-certificates が入っていません。