### PR TITLE
fix: Docker コンテナ内の git push 認証を修正

### DIFF
--- a/.github/workflows/issue-to-markdown.yml
+++ b/.github/workflows/issue-to-markdown.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   create-md:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -17,6 +17,7 @@ export interface ActionContext {
     owner: string;
     repo: string;
   };
+  token: string;
 }
 
 export interface ActionDeps {
@@ -49,6 +50,10 @@ export async function runAction(
   // Docker コンテナ内の git ユーザー設定
   await exec("git", ["config", "user.name", "github-actions[bot]"]);
   await exec("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+
+  // GITHUB_TOKEN で認証できるよう remote URL を設定
+  const authUrl = `https://x-access-token:${context.token}@github.com/${repo.owner}/${repo.repo}.git`;
+  await exec("git", ["remote", "set-url", "origin", authUrl]);
 
   // ブランチ作成
   await exec("git", ["checkout", "-b", branchName]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ async function main(): Promise<void> {
         baseBranch: core.getInput("base-branch") || "main",
       },
       repo: github.context.repo,
+      token,
     };
 
     const execFn = (cmd: string, args: string[]): Promise<number> =>

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -27,6 +27,7 @@ describe("runAction", () => {
         owner: "kumamoto",
         repo: "my-blog",
       },
+      token: "fake-token",
     };
 
     mockExec = vi.fn().mockResolvedValue(0);
@@ -77,6 +78,7 @@ describe("runAction", () => {
       "git config --global safe.directory /github/workspace",
       "git config user.name github-actions[bot]",
       "git config user.email 41898282+github-actions[bot]@users.noreply.github.com",
+      "git remote set-url origin https://x-access-token:fake-token@github.com/kumamoto/my-blog.git",
       "git checkout -b content/issue-42",
       "mkdir -p src/content/posts",
       "git add src/content/posts/42.md",


### PR DESCRIPTION
## Summary
- Docker コンテナ内の `git push` が `GITHUB_TOKEN` の認証情報を持たず 403 で失敗していた問題を修正
- `actions/checkout` が設定する認証情報はホスト側のみで、Docker コンテナには引き継がれないため、remote URL にトークンを埋め込む方式で対応
- ワークフローに `contents: write` / `pull-requests: write` の permissions を明示

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `.github/workflows/issue-to-markdown.yml` | `permissions` を追加（`contents: write`, `pull-requests: write`） |
| `src/action.ts` | `ActionContext` に `token` を追加、`git remote set-url` でトークン認証を設定 |
| `src/index.ts` | 環境変数の `GITHUB_TOKEN` を context に渡すように変更 |
| `test/action.test.ts` | 上記変更に合わせてテストを更新 |

## Test plan
- [ ] Issue を Reopen → Close してワークフローが `git push` まで成功することを確認
- [ ] PR が自動作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)