### PR TITLE
feat: change output file extension from .md to .mdx

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: "Issue to Astro"
-description: "GitHub Issue を close したときに Markdown ファイルを自動生成し PR を作成する"
+description: "GitHub Issue を close したときに MDX ファイルを自動生成し PR を作成する"
 author: "kumamoto"
 
 inputs:
   output-dir:
-    description: "Markdown ファイルの出力先ディレクトリ"
+    description: "MDX ファイルの出力先ディレクトリ"
     required: false
     default: "src/content/posts"
   branch-prefix:
@@ -26,7 +26,7 @@ outputs:
   branch-name:
     description: "作成されたブランチ名"
   file-path:
-    description: "生成された Markdown ファイルのパス"
+    description: "生成された MDX ファイルのパス"
 
 runs:
   using: "docker"

--- a/src/generate-markdown.ts
+++ b/src/generate-markdown.ts
@@ -28,5 +28,5 @@ ${content}`;
 
 export function getFilePath(outputDir: string, issueNumber: number): string {
   const dir = outputDir.replace(/\/+$/, "");
-  return `${dir}/${issueNumber}.md`;
+  return `${dir}/${issueNumber}.mdx`;
 }

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -56,7 +56,7 @@ describe("runAction", () => {
   it("正しいファイルパスを返す", async () => {
     const result = await runAction(mockContext, { exec: mockExec, octokit: mockOctokit, writeFile: mockWriteFile });
 
-    expect(result.filePath).toBe("src/content/posts/42.md");
+    expect(result.filePath).toBe("src/content/posts/42.mdx");
   });
 
   it("PR の URL を返す", async () => {
@@ -81,7 +81,7 @@ describe("runAction", () => {
       "git remote set-url origin https://x-access-token:fake-token@github.com/kumamoto/my-blog.git",
       "git checkout -b content/issue-42",
       "mkdir -p src/content/posts",
-      "git add src/content/posts/42.md",
+      "git add src/content/posts/42.mdx",
       "git commit -m docs(content): add post from issue #42",
       "git push origin content/issue-42",
     ]);
@@ -113,10 +113,10 @@ describe("runAction", () => {
     });
 
     expect(localMockWriteFile).toHaveBeenCalledWith(
-      "src/content/posts/42.md",
+      "src/content/posts/42.mdx",
       expect.stringContaining('title: "新しい記事のタイトル"'),
     );
-    expect(writtenFiles["src/content/posts/42.md"]).toContain(
+    expect(writtenFiles["src/content/posts/42.mdx"]).toContain(
       "Issue の本文がここに入ります。",
     );
   });

--- a/test/get-file-path.test.ts
+++ b/test/get-file-path.test.ts
@@ -4,17 +4,17 @@ import { getFilePath } from "../src/generate-markdown.js";
 describe("getFilePath", () => {
   it("Issue 番号からファイルパスを生成する", () => {
     expect(getFilePath("src/content/posts", 42)).toBe(
-      "src/content/posts/42.md",
+      "src/content/posts/42.mdx",
     );
   });
 
   it("出力ディレクトリ末尾のスラッシュを正規化する", () => {
     expect(getFilePath("src/content/posts/", 42)).toBe(
-      "src/content/posts/42.md",
+      "src/content/posts/42.mdx",
     );
   });
 
   it("異なるディレクトリでも正しく生成する", () => {
-    expect(getFilePath("content/blog", 1)).toBe("content/blog/1.md");
+    expect(getFilePath("content/blog", 1)).toBe("content/blog/1.mdx");
   });
 });


### PR DESCRIPTION
## Summary
- 生成ファイルの拡張子を `.md` から `.mdx` に変更
- `action.yml` の description を MDX に更新
- 関連するテストを全て更新済み（全14テスト通過）

## Test plan
- [x] `pnpm test` で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)