### PR TITLE
feat: generate index.mdx inside issue number directory

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type * as github from "@actions/github";
 import { generateMarkdown, getFilePath } from "./generate-markdown.js";
 import type { Issue } from "./generate-markdown.js";
@@ -59,7 +60,7 @@ export async function runAction(
   await exec("git", ["checkout", "-b", branchName]);
 
   // ディレクトリ作成 & ファイル書き出し
-  await exec("mkdir", ["-p", inputs.outputDir]);
+  await exec("mkdir", ["-p", dirname(filePath)]);
   writeFile(filePath, markdown);
 
   // コミット & プッシュ

--- a/src/generate-markdown.ts
+++ b/src/generate-markdown.ts
@@ -28,5 +28,5 @@ ${content}`;
 
 export function getFilePath(outputDir: string, issueNumber: number): string {
   const dir = outputDir.replace(/\/+$/, "");
-  return `${dir}/${issueNumber}.mdx`;
+  return `${dir}/${issueNumber}/index.mdx`;
 }

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -56,7 +56,7 @@ describe("runAction", () => {
   it("正しいファイルパスを返す", async () => {
     const result = await runAction(mockContext, { exec: mockExec, octokit: mockOctokit, writeFile: mockWriteFile });
 
-    expect(result.filePath).toBe("src/content/posts/42.mdx");
+    expect(result.filePath).toBe("src/content/posts/42/index.mdx");
   });
 
   it("PR の URL を返す", async () => {
@@ -80,8 +80,8 @@ describe("runAction", () => {
       "git config user.email 41898282+github-actions[bot]@users.noreply.github.com",
       "git remote set-url origin https://x-access-token:fake-token@github.com/kumamoto/my-blog.git",
       "git checkout -b content/issue-42",
-      "mkdir -p src/content/posts",
-      "git add src/content/posts/42.mdx",
+      "mkdir -p src/content/posts/42",
+      "git add src/content/posts/42/index.mdx",
       "git commit -m docs(content): add post from issue #42",
       "git push origin content/issue-42",
     ]);
@@ -113,10 +113,10 @@ describe("runAction", () => {
     });
 
     expect(localMockWriteFile).toHaveBeenCalledWith(
-      "src/content/posts/42.mdx",
+      "src/content/posts/42/index.mdx",
       expect.stringContaining('title: "新しい記事のタイトル"'),
     );
-    expect(writtenFiles["src/content/posts/42.mdx"]).toContain(
+    expect(writtenFiles["src/content/posts/42/index.mdx"]).toContain(
       "Issue の本文がここに入ります。",
     );
   });

--- a/test/get-file-path.test.ts
+++ b/test/get-file-path.test.ts
@@ -2,19 +2,19 @@ import { describe, it, expect } from "vitest";
 import { getFilePath } from "../src/generate-markdown.js";
 
 describe("getFilePath", () => {
-  it("Issue 番号からファイルパスを生成する", () => {
+  it("Issue 番号からディレクトリ付きファイルパスを生成する", () => {
     expect(getFilePath("src/content/posts", 42)).toBe(
-      "src/content/posts/42.mdx",
+      "src/content/posts/42/index.mdx",
     );
   });
 
   it("出力ディレクトリ末尾のスラッシュを正規化する", () => {
     expect(getFilePath("src/content/posts/", 42)).toBe(
-      "src/content/posts/42.mdx",
+      "src/content/posts/42/index.mdx",
     );
   });
 
   it("異なるディレクトリでも正しく生成する", () => {
-    expect(getFilePath("content/blog", 1)).toBe("content/blog/1.mdx");
+    expect(getFilePath("content/blog", 1)).toBe("content/blog/1/index.mdx");
   });
 });


### PR DESCRIPTION
## Summary
- 出力ファイル構造を `{outputDir}/{issueNumber}.mdx` から `{outputDir}/{issueNumber}/index.mdx` に変更
- `mkdir -p` の対象をファイルパスの親ディレクトリに変更し、Issue番号のサブディレクトリも自動作成されるように対応
- 関連するテストをすべて新しいパス形式に更新

## Test plan
- [x] `pnpm test` で全14テストがパス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)