### PR TITLE
feat: download images from issue body and save locally

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import type * as github from "@actions/github";
 import { generateMarkdown, getFilePath } from "./generate-markdown.js";
 import type { Issue } from "./generate-markdown.js";
+import { downloadImages } from "./download-images.js";
 
 export type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -24,7 +25,8 @@ export interface ActionContext {
 export interface ActionDeps {
   exec: (cmd: string, args: string[]) => Promise<number>;
   octokit: Octokit;
-  writeFile?: (path: string, content: string) => void;
+  writeFile?: (path: string, content: string | Buffer) => void;
+  fetch?: typeof globalThis.fetch;
 }
 
 export interface ActionResult {
@@ -38,12 +40,19 @@ export async function runAction(
   deps: ActionDeps,
 ): Promise<ActionResult> {
   const { issue, inputs, repo } = context;
-  const { exec, octokit, writeFile = writeFileSync } = deps;
+  const { exec, octokit, writeFile = writeFileSync, fetch: fetchFn = globalThis.fetch } = deps;
 
   const branchName = `${inputs.branchPrefix}${issue.number}`;
   const filePath = getFilePath(inputs.outputDir, issue.number);
-  const markdown = generateMarkdown(issue);
   const commitMessage = `${inputs.commitType}(content): add post from issue #${issue.number}`;
+
+  // 画像ダウンロード処理
+  const imageResult = issue.body
+    ? await downloadImages(issue.body, { fetch: fetchFn })
+    : { body: issue.body ?? "", images: new Map<string, Buffer>() };
+
+  const processedIssue = { ...issue, body: imageResult.body };
+  const markdown = generateMarkdown(processedIssue);
 
   // Docker コンテナ内の所有者不一致を回避
   await exec("git", ["config", "--global", "safe.directory", "/github/workspace"]);
@@ -60,11 +69,17 @@ export async function runAction(
   await exec("git", ["checkout", "-b", branchName]);
 
   // ディレクトリ作成 & ファイル書き出し
-  await exec("mkdir", ["-p", dirname(filePath)]);
+  const imageDir = dirname(filePath);
+  await exec("mkdir", ["-p", imageDir]);
   writeFile(filePath, markdown);
 
-  // コミット & プッシュ
-  await exec("git", ["add", filePath]);
+  // 画像ファイル書き出し
+  for (const [filename, buffer] of imageResult.images) {
+    writeFile(`${imageDir}/${filename}`, buffer);
+  }
+
+  // コミット & プッシュ（ディレクトリごと add）
+  await exec("git", ["add", imageDir]);
   await exec("git", ["commit", "-m", commitMessage]);
   await exec("git", ["push", "origin", branchName]);
 

--- a/src/download-images.ts
+++ b/src/download-images.ts
@@ -1,0 +1,98 @@
+export interface ImageDownloadResult {
+  body: string;
+  images: Map<string, Buffer>;
+}
+
+export interface DownloadImagesDeps {
+  fetch: typeof globalThis.fetch;
+}
+
+const MD_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g;
+const HTML_IMG_REGEX = /<img\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
+
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/svg+xml": ".svg",
+};
+
+const KNOWN_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+
+function getExtensionFromUrl(url: string): string | null {
+  try {
+    const pathname = new URL(url).pathname;
+    const lastDot = pathname.lastIndexOf(".");
+    if (lastDot === -1) return null;
+    const ext = pathname.slice(lastDot).toLowerCase();
+    return KNOWN_EXTENSIONS.has(ext) ? ext : null;
+  } catch {
+    return null;
+  }
+}
+
+function getExtensionFromContentType(contentType: string): string {
+  const mime = contentType.split(";")[0].trim().toLowerCase();
+  return CONTENT_TYPE_TO_EXT[mime] ?? ".png";
+}
+
+export async function downloadImages(
+  body: string,
+  deps: DownloadImagesDeps,
+): Promise<ImageDownloadResult> {
+  // 全画像URLを出現順に収集
+  const urlEntries: { url: string; index: number }[] = [];
+
+  for (const match of body.matchAll(MD_IMAGE_REGEX)) {
+    urlEntries.push({ url: match[2], index: match.index! });
+  }
+  for (const match of body.matchAll(HTML_IMG_REGEX)) {
+    urlEntries.push({ url: match[1], index: match.index! });
+  }
+
+  // 出現順にソート
+  urlEntries.sort((a, b) => a.index - b.index);
+
+  if (urlEntries.length === 0) {
+    return { body, images: new Map() };
+  }
+
+  // 重複排除しつつダウンロード
+  const urlToFilename = new Map<string, string>();
+  const images = new Map<string, Buffer>();
+  let counter = 0;
+
+  for (const { url } of urlEntries) {
+    if (urlToFilename.has(url)) continue;
+
+    try {
+      const response = await deps.fetch(url);
+      if (!response.ok) continue;
+
+      counter++;
+      const buffer = Buffer.from(await response.arrayBuffer());
+      const ext = getExtensionFromUrl(url) ??
+        getExtensionFromContentType(response.headers.get("content-type") ?? "");
+      const filename = `image-${String(counter).padStart(3, "0")}${ext}`;
+
+      urlToFilename.set(url, filename);
+      images.set(filename, buffer);
+    } catch {
+      // ダウンロード失敗時は元URLを維持
+    }
+  }
+
+  // body内のURLを置換
+  let result = body.replace(MD_IMAGE_REGEX, (_match, alt, url) => {
+    const filename = urlToFilename.get(url);
+    return filename ? `![${alt}](./${filename})` : `![${alt}](${url})`;
+  });
+
+  result = result.replace(HTML_IMG_REGEX, (match, url) => {
+    const filename = urlToFilename.get(url);
+    return filename ? match.replace(url, `./${filename}`) : match;
+  });
+
+  return { body: result, images };
+}

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -81,7 +81,7 @@ describe("runAction", () => {
       "git remote set-url origin https://x-access-token:fake-token@github.com/kumamoto/my-blog.git",
       "git checkout -b content/issue-42",
       "mkdir -p src/content/posts/42",
-      "git add src/content/posts/42/index.mdx",
+      "git add src/content/posts/42",
       "git commit -m docs(content): add post from issue #42",
       "git push origin content/issue-42",
     ]);
@@ -98,6 +98,46 @@ describe("runAction", () => {
       base: "main",
       body: "Closes #42",
     });
+  });
+
+  it("画像付き Issue で画像ファイルも writeFile で書き出す", async () => {
+    const imageBuffer = Buffer.from(new ArrayBuffer(8));
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      headers: new Headers({ "content-type": "image/png" }),
+    });
+
+    const contextWithImage = {
+      ...mockContext,
+      issue: {
+        ...mockContext.issue,
+        body: "本文 ![screenshot](https://example.com/photo.png) です",
+      },
+    };
+
+    const writeCalls: Array<[string, string | Buffer]> = [];
+    const localMockWriteFile = vi.fn((path: string, content: string | Buffer) => {
+      writeCalls.push([path, content]);
+    });
+
+    await runAction(contextWithImage, {
+      exec: mockExec,
+      octokit: mockOctokit,
+      writeFile: localMockWriteFile,
+      fetch: mockFetch,
+    });
+
+    // MDXファイルが書き出される
+    expect(localMockWriteFile).toHaveBeenCalledWith(
+      "src/content/posts/42/index.mdx",
+      expect.stringContaining("![screenshot](./image-001.png)"),
+    );
+    // 画像ファイルが書き出される
+    expect(localMockWriteFile).toHaveBeenCalledWith(
+      "src/content/posts/42/image-001.png",
+      expect.any(Buffer),
+    );
   });
 
   it("Markdown ファイルの内容を writeFile コールバックで書き出す", async () => {

--- a/test/download-images.test.ts
+++ b/test/download-images.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { downloadImages } from "../src/download-images.js";
+
+function createMockFetch(contentType = "image/png") {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    headers: new Headers({ "content-type": contentType }),
+  });
+}
+
+function createFailingFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 404,
+  });
+}
+
+describe("downloadImages", () => {
+  it("Markdown 画像の URL を検出してローカルパスに書き換える", async () => {
+    const body = "テスト ![screenshot](https://example.com/photo.png) です";
+    const mockFetch = createMockFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe("テスト ![screenshot](./image-001.png) です");
+    expect(result.images.size).toBe(1);
+    expect(result.images.has("image-001.png")).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith("https://example.com/photo.png");
+  });
+
+  it("複数の画像を連番で処理する", async () => {
+    const body = "![a](https://example.com/a.png)\n![b](https://example.com/b.jpg)";
+    const mockFetch = createMockFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe("![a](./image-001.png)\n![b](./image-002.jpg)");
+    expect(result.images.size).toBe(2);
+    expect(result.images.has("image-001.png")).toBe(true);
+    expect(result.images.has("image-002.jpg")).toBe(true);
+  });
+
+  it("HTML img タグの src を検出してローカルパスに書き換える", async () => {
+    const body = '<img src="https://example.com/photo.png" alt="test">';
+    const mockFetch = createMockFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe('<img src="./image-001.png" alt="test">');
+    expect(result.images.size).toBe(1);
+  });
+
+  it("Markdown 画像と HTML img タグが混在するケースを処理する", async () => {
+    const body = '![md](https://example.com/a.png)\n<img src="https://example.com/b.jpg">';
+    const mockFetch = createMockFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe('![md](./image-001.png)\n<img src="./image-002.jpg">');
+    expect(result.images.size).toBe(2);
+  });
+
+  it("画像がない場合は body をそのまま返す", async () => {
+    const body = "画像のないテキストです";
+    const mockFetch = createMockFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe(body);
+    expect(result.images.size).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("ダウンロード失敗時は元の URL を維持する", async () => {
+    const body = "![fail](https://example.com/missing.png)";
+    const mockFetch = createFailingFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe("![fail](https://example.com/missing.png)");
+    expect(result.images.size).toBe(0);
+  });
+
+  it("URL に拡張子がない場合は Content-Type から判定する", async () => {
+    const body = "![img](https://example.com/image-data)";
+    const mockFetch = createMockFetch("image/jpeg");
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe("![img](./image-001.jpg)");
+    expect(result.images.has("image-001.jpg")).toBe(true);
+  });
+
+  it("拡張子も Content-Type も不明な場合は .png をデフォルトにする", async () => {
+    const body = "![img](https://example.com/blob)";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      headers: new Headers({ "content-type": "application/octet-stream" }),
+    });
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe("![img](./image-001.png)");
+    expect(result.images.has("image-001.png")).toBe(true);
+  });
+
+  it("同一 URL が複数箇所にある場合は 1 回だけダウンロードする", async () => {
+    const body = "![a](https://example.com/same.png)\n![b](https://example.com/same.png)";
+    const mockFetch = createMockFetch();
+
+    const result = await downloadImages(body, { fetch: mockFetch });
+
+    expect(result.body).toBe("![a](./image-001.png)\n![b](./image-001.png)");
+    expect(result.images.size).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Issue本文中の画像（Markdown `![alt](url)` / HTML `<img src="url">`）を検出し、ダウンロードして `index.mdx` と同じディレクトリに保存
- MDX内の画像URLをローカル相対パス（`./image-001.png`）に書き換え
- DL失敗時は元URLを維持、同一URLの重複排除、拡張子はURL/Content-Type/デフォルト`.png`の順で判定

## Test plan
- [x] `pnpm test` で全24テスト通過（新規9テスト + 既存15テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)