### PR TITLE
fix: use force push to handle existing remote branches

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -81,7 +81,7 @@ export async function runAction(
   // コミット & プッシュ（ディレクトリごと add）
   await exec("git", ["add", imageDir]);
   await exec("git", ["commit", "-m", commitMessage]);
-  await exec("git", ["push", "origin", branchName]);
+  await exec("git", ["push", "--force", "origin", branchName]);
 
   // PR 作成
   const { data: pr } = await octokit.rest.pulls.create({

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -83,7 +83,7 @@ describe("runAction", () => {
       "mkdir -p src/content/posts/42",
       "git add src/content/posts/42",
       "git commit -m docs(content): add post from issue #42",
-      "git push origin content/issue-42",
+      "git push --force origin content/issue-42",
     ]);
   });
 


### PR DESCRIPTION
When the same issue is closed again, the remote branch already exists and a normal push is rejected. Force push resolves this conflict.